### PR TITLE
Reset prerender cache correctly

### DIFF
--- a/django_seo_js/backends/prerender.py
+++ b/django_seo_js/backends/prerender.py
@@ -1,3 +1,4 @@
+import json
 from django_seo_js import settings
 from .base import SEOBackendBase, RequestsBasedBackend
 
@@ -55,7 +56,7 @@ class PrerenderIO(SEOBackendBase, RequestsBasedBackend):
         if regex:
             data["regex"] = regex
 
-        r = self.session.post(self.RECACHE_URL, headers=headers, data=data)
+        r = self.session.post(self.RECACHE_URL, headers=headers, data=json.dumps(data))
         return r.status_code < 500
 
 


### PR DESCRIPTION
I figured out that we have to convert `data` to string before sending the request, otherwise it returns 400 (Bad request) response. Prerender.io [says](https://prerender.io/documentation/recaching) that cache will be deleted if we're getting 4XX reponse, but it is not true.

This PR converts json data to string and it fixes the problem.